### PR TITLE
OIDCPolicy

### DIFF
--- a/ian.md
+++ b/ian.md
@@ -79,6 +79,7 @@ EOF
 ```sh
 helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
 helm install kuadrant-operator kuadrant/kuadrant-operator \
+  --version 1.3.0-alpha1\
   --namespace kuadrant-system \
   --create-namespace \
   --wait


### PR DESCRIPTION
Replaces the OIDC part of the `baker-auth` AuthPolicy with an OIDCPolicy.

### Caveats

- Requires Kuadrant 1.3.0-alpha1

### Known issues

- The main AuthPolicy created out of the OIDCPolicy resource is reported as not enforced even though it is actually being enforced

```
❯ kubectl get authpolicies -n bakery-apps -o wide              

NAME                  ACCEPTED   ENFORCED   TARGETKIND   TARGETNAME            TARGETSECTION   AGE
baker-oidc            True       False      HTTPRoute    baker-route                           31m
baker-oidc-callback   True       True       HTTPRoute    baker-oidc-callback                   31m
baker-pods            True       True       HTTPRoute    baker-route                           18m
```